### PR TITLE
Issue #3, changes in the operator + of the iterator class

### DIFF
--- a/src/ordered_map.h
+++ b/src/ordered_map.h
@@ -280,17 +280,14 @@ public:
             return lhs.m_iterator >= rhs.m_iterator; 
         }
 
-        friend difference_type operator+(const ordered_iterator& lhs, const ordered_iterator& rhs) { 
-            return lhs.m_iterator + rhs.m_iterator; 
-        }
-        
+        friend ordered_iterator operator+(difference_type n, const ordered_iterator& it) { 
+			return n + it.m_iterator;
+		}
+
         friend difference_type operator-(const ordered_iterator& lhs, const ordered_iterator& rhs) { 
             return lhs.m_iterator - rhs.m_iterator; 
         }
 
-        friend ordered_iterator operator+(difference_type n, const ordered_iterator& it) { 
-			return n + it.m_iterator;
-		}
     private:
         iterator m_iterator;
     };

--- a/src/ordered_map.h
+++ b/src/ordered_map.h
@@ -279,7 +279,7 @@ public:
         friend bool operator>=(const ordered_iterator& lhs, const ordered_iterator& rhs) { 
             return lhs.m_iterator >= rhs.m_iterator; 
         }
-        
+
         friend difference_type operator+(const ordered_iterator& lhs, const ordered_iterator& rhs) { 
             return lhs.m_iterator + rhs.m_iterator; 
         }
@@ -287,6 +287,10 @@ public:
         friend difference_type operator-(const ordered_iterator& lhs, const ordered_iterator& rhs) { 
             return lhs.m_iterator - rhs.m_iterator; 
         }
+
+        friend ordered_iterator operator+(difference_type n, const ordered_iterator& it) { 
+			return n + it.m_iterator;
+		}
     private:
         iterator m_iterator;
     };

--- a/src/ordered_map.h
+++ b/src/ordered_map.h
@@ -281,8 +281,8 @@ public:
         }
 
         friend ordered_iterator operator+(difference_type n, const ordered_iterator& it) { 
-			return n + it.m_iterator;
-		}
+            return n + it.m_iterator;
+        }
 
         friend difference_type operator-(const ordered_iterator& lhs, const ordered_iterator& rhs) { 
             return lhs.m_iterator - rhs.m_iterator; 

--- a/tests/ordered_map_tests.cpp
+++ b/tests/ordered_map_tests.cpp
@@ -269,6 +269,53 @@ BOOST_AUTO_TEST_CASE(test_reverse_iterator) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(test_iterator_arithmetic) {
+    tsl::ordered_map<int64_t, int64_t> map = {{1, 10}, {2, 20}, {3, 30}, 
+                                              {4, 40}, {5, 50}, {6, 60}};
+                                              
+    tsl::ordered_map<int64_t, int64_t>::const_iterator it;
+    tsl::ordered_map<int64_t, int64_t>::const_iterator it2;
+    
+    it = map.cbegin();
+    // it += n
+    it += 3;
+    BOOST_CHECK_EQUAL(it->second, 40);
+    
+    
+    
+    // it + n
+    BOOST_CHECK_EQUAL((map.cbegin() + 3)->second, 40);
+    // n + it
+    BOOST_CHECK_EQUAL((3 + map.cbegin())->second, 40);
+    
+    
+    
+    it = map.cbegin() + 4;
+    // it -= n
+    it -= 2;
+    BOOST_CHECK_EQUAL(it->second, 30);
+    
+    
+    
+    // it - n
+    BOOST_CHECK_EQUAL((it - 1)->second, 20);
+    
+    
+    
+    it = map.cbegin() + 2;
+    it2 = map.cbegin() + 4;
+    // it - it
+    BOOST_CHECK_EQUAL(it2 - it, 2);
+    
+    
+    
+    // it[n]
+    BOOST_CHECK_EQUAL(map.cbegin()[2].second, 30);
+    
+    it = map.cbegin() + 1;
+    // it[n]
+    BOOST_CHECK_EQUAL(it[2].second, 40);
+}
 
 
 /**


### PR DESCRIPTION
This patch includes the following two changes:
1. Override `operator+(difference_type, const ordered_iterator&)` which is required in a random access iterator.
2. Remove `operator+(const ordered_iterator& lhs, const ordered_iterator& rhs)`, which is not a standard operator in iterators.