### PR TITLE
Add the possibility to use the library without exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Two classes are provided: `tsl::ordered_map` and `tsl::ordered_set`.
 - O(1) average time complexity for lookups with performances similar to `std::unordered_map` but with faster insertions and reduced memory usage (see [benchmark](https://tessil.github.io/2016/08/29/benchmark-hopscotch-map.html) for details).
 - Provide random access iterators and also reverse iterators.
 - Support for heterogeneous lookups (e.g. if you have a map that uses `std::unique_ptr<int>` as key, you could use an `int*` or a `std::uintptr_t` for example as key parameter for `find`, see [example](https://github.com/Tessil/ordered-map#heterogeneous-lookup)).
-- Can be used without exceptions support (through `-fno-exceptions` option on Clang and GCC, or without an `/EH` option on MSVC), `std::terminate` is used in replacement of the `throw` instruction when exceptions are disabled.
+- The library can be used with exceptions disabled (through `-fno-exceptions` option on Clang and GCC, without an `/EH` option on MSVC or simply by defining `TSL_NO_EXCEPTIONS`). `std::terminate` is used in replacement of the `throw` instruction when exceptions are disabled.
 - API closely similar to `std::unordered_map` and `std::unordered_set`.
 
 ### Differences compare to `std::unordered_map`

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Two classes are provided: `tsl::ordered_map` and `tsl::ordered_set`.
 - O(1) average time complexity for lookups with performances similar to `std::unordered_map` but with faster insertions and reduced memory usage (see [benchmark](https://tessil.github.io/2016/08/29/benchmark-hopscotch-map.html) for details).
 - Provide random access iterators and also reverse iterators.
 - Support for heterogeneous lookups (e.g. if you have a map that uses `std::unique_ptr<int>` as key, you could use an `int*` or a `std::uintptr_t` for example as key parameter for `find`, see [example](https://github.com/Tessil/ordered-map#heterogeneous-lookup)).
+- Can be used without exceptions support (through `-fno-exceptions` option on Clang and GCC, or without an `/EH` option on MSVC), `std::terminate` is used in replacement of the `throw` instruction when exceptions are disabled.
 - API closely similar to `std::unordered_map` and `std::unordered_set`.
 
 ### Differences compare to `std::unordered_map`

--- a/tsl/ordered_hash.h
+++ b/tsl/ordered_hash.h
@@ -31,6 +31,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <functional>
 #include <iterator>
 #include <limits>
@@ -58,7 +59,7 @@
 #endif
 
 
-/*
+/**
  * Only activate tsl_assert if TSL_DEBUG is defined. 
  * This way we avoid the performance hit when NDEBUG is not defined with assert as tsl_assert is used a lot
  * (people usually compile with "-O3" and not "-O3 -DNDEBUG").
@@ -71,6 +72,17 @@
     #endif
 #endif
 
+
+/**
+ * If exceptions are enabled, throw the exception passed in parameter, otherwise std::abort.
+ */
+#ifndef TSL_THROW_OR_ABORT
+    #if defined(__cpp_exceptions) || (defined (_MSC_VER) && defined (__CPPUNWIND))
+    #define TSL_THROW_OR_ABORT(ex) throw ex
+    #else
+    #define TSL_THROW_OR_ABORT(ex) std::abort()
+    #endif
+#endif
 
 namespace tsl {
 
@@ -363,7 +375,7 @@ public:
     {
         bucket_count = round_up_to_power_of_two(bucket_count);
         if(bucket_count > max_bucket_count()) {
-            throw std::length_error("The map exceeds its maxmimum size.");
+            TSL_THROW_OR_ABORT(std::length_error("The map exceeds its maxmimum size."));
         }
         tsl_assert(bucket_count > 0);
         
@@ -670,7 +682,7 @@ public:
             return it.value();
         }
         else {
-            throw std::out_of_range("Couldn't find the key.");
+            TSL_THROW_OR_ABORT(std::out_of_range("Couldn't find the key."));
         }
     }
     
@@ -989,7 +1001,7 @@ private:
         }
         
         if(bucket_count > max_bucket_count()) {
-            throw std::length_error("The map exceeds its maxmimum size.");
+            TSL_THROW_OR_ABORT(std::length_error("The map exceeds its maxmimum size."));
         }
         
         
@@ -1135,7 +1147,7 @@ private:
         }
         
         if(size() >= max_size()) {
-            throw std::length_error("We reached the maximum size for the hash table.");
+            TSL_THROW_OR_ABORT(std::length_error("We reached the maximum size for the hash table."));
         }
         
         

--- a/tsl/ordered_hash.h
+++ b/tsl/ordered_hash.h
@@ -77,7 +77,7 @@
  * If exceptions are enabled, throw the exception passed in parameter, otherwise std::abort.
  */
 #ifndef TSL_THROW_OR_ABORT
-    #if defined(__cpp_exceptions) || (defined (_MSC_VER) && defined (__CPPUNWIND))
+    #if defined(__cpp_exceptions) || defined(__EXCEPTIONS) || (defined (_MSC_VER) && defined (__CPPUNWIND))
     #define TSL_THROW_OR_ABORT(ex) throw ex
     #else
     #define TSL_THROW_OR_ABORT(ex) std::abort()

--- a/tsl/ordered_hash.h
+++ b/tsl/ordered_hash.h
@@ -77,7 +77,7 @@
  * If exceptions are enabled, throw the exception passed in parameter, otherwise std::terminate.
  */
 #ifndef TSL_THROW_OR_TERMINATE
-    #if defined(__cpp_exceptions) || defined(__EXCEPTIONS) || (defined (_MSC_VER) && defined (_CPPUNWIND))
+    #if (defined(__cpp_exceptions) || defined(__EXCEPTIONS) || (defined (_MSC_VER) && defined (_CPPUNWIND))) && !defined(TSL_NO_EXCEPTIONS)
     #define TSL_THROW_OR_TERMINATE(ex) throw ex
     #else
     #define TSL_THROW_OR_TERMINATE(ex) std::terminate()

--- a/tsl/ordered_hash.h
+++ b/tsl/ordered_hash.h
@@ -77,7 +77,7 @@
  * If exceptions are enabled, throw the exception passed in parameter, otherwise std::abort.
  */
 #ifndef TSL_THROW_OR_ABORT
-    #if defined(__cpp_exceptions) || defined(__EXCEPTIONS) || (defined (_MSC_VER) && defined (__CPPUNWIND))
+    #if defined(__cpp_exceptions) || defined(__EXCEPTIONS) || (defined (_MSC_VER) && defined (_CPPUNWIND))
     #define TSL_THROW_OR_ABORT(ex) throw ex
     #else
     #define TSL_THROW_OR_ABORT(ex) std::abort()

--- a/tsl/ordered_hash.h
+++ b/tsl/ordered_hash.h
@@ -31,7 +31,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
-#include <cstdlib>
+#include <exception>
 #include <functional>
 #include <iterator>
 #include <limits>
@@ -74,13 +74,13 @@
 
 
 /**
- * If exceptions are enabled, throw the exception passed in parameter, otherwise std::abort.
+ * If exceptions are enabled, throw the exception passed in parameter, otherwise std::terminate.
  */
-#ifndef TSL_THROW_OR_ABORT
+#ifndef TSL_THROW_OR_TERMINATE
     #if defined(__cpp_exceptions) || defined(__EXCEPTIONS) || (defined (_MSC_VER) && defined (_CPPUNWIND))
-    #define TSL_THROW_OR_ABORT(ex) throw ex
+    #define TSL_THROW_OR_TERMINATE(ex) throw ex
     #else
-    #define TSL_THROW_OR_ABORT(ex) std::abort()
+    #define TSL_THROW_OR_TERMINATE(ex) std::terminate()
     #endif
 #endif
 
@@ -375,7 +375,7 @@ public:
     {
         bucket_count = round_up_to_power_of_two(bucket_count);
         if(bucket_count > max_bucket_count()) {
-            TSL_THROW_OR_ABORT(std::length_error("The map exceeds its maxmimum size."));
+            TSL_THROW_OR_TERMINATE(std::length_error("The map exceeds its maxmimum size."));
         }
         tsl_assert(bucket_count > 0);
         
@@ -682,7 +682,7 @@ public:
             return it.value();
         }
         else {
-            TSL_THROW_OR_ABORT(std::out_of_range("Couldn't find the key."));
+            TSL_THROW_OR_TERMINATE(std::out_of_range("Couldn't find the key."));
         }
     }
     
@@ -1001,7 +1001,7 @@ private:
         }
         
         if(bucket_count > max_bucket_count()) {
-            TSL_THROW_OR_ABORT(std::length_error("The map exceeds its maxmimum size."));
+            TSL_THROW_OR_TERMINATE(std::length_error("The map exceeds its maxmimum size."));
         }
         
         
@@ -1147,7 +1147,7 @@ private:
         }
         
         if(size() >= max_size()) {
-            TSL_THROW_OR_ABORT(std::length_error("We reached the maximum size for the hash table."));
+            TSL_THROW_OR_TERMINATE(std::length_error("We reached the maximum size for the hash table."));
         }
         
         


### PR DESCRIPTION
This PR adds the possibility to use the library with exceptions disabled (through `-fno-exceptions` option on Clang and GCC, without an `/EH` option on MSVC or simply by defining `TSL_NO_EXCEPTIONS`). `std::terminate` is used in replacement of the `throw` instruction when exceptions are disabled.