### PR TITLE
Bug correction, set a moved hash map/set in a valid state so that it can still be used even after a move.

### DIFF
--- a/tests/custom_allocator_tests.cpp
+++ b/tests/custom_allocator_tests.cpp
@@ -128,19 +128,19 @@ bool operator!=(const custom_allocator<T>&, const custom_allocator<U>&) {
 BOOST_AUTO_TEST_SUITE(test_custom_allocator)
 
 BOOST_AUTO_TEST_CASE(test_custom_allocator_1) {
-//         nb_global_new = 0;
-        nb_custom_allocs = 0;
-        
-        tsl::ordered_map<int, int, std::hash<int>, std::equal_to<int>, 
-                         custom_allocator<std::pair<int, int>>> map;
-        
-        const int nb_elements = 10000;
-        for(int i = 0; i < nb_elements; i++) {
-            map.insert({i, i*2});
-        }
-        
-        BOOST_CHECK_NE(nb_custom_allocs, 0);
-//         BOOST_CHECK_EQUAL(nb_global_new, 0);
+//    nb_global_new = 0;
+    nb_custom_allocs = 0;
+    
+    tsl::ordered_map<int, int, std::hash<int>, std::equal_to<int>, 
+                     custom_allocator<std::pair<int, int>>> map;
+    
+    const int nb_elements = 10000;
+    for(int i = 0; i < nb_elements; i++) {
+        map.insert({i, i*2});
+    }
+    
+    BOOST_CHECK_NE(nb_custom_allocs, 0);
+//    BOOST_CHECK_EQUAL(nb_global_new, 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/ordered_map_tests.cpp
+++ b/tests/ordered_map_tests.cpp
@@ -422,20 +422,16 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_erase_loop_range, HMap, test_types) {
     const std::size_t range = 5;
     std::size_t nb_values = 1000;
     
-    BOOST_REQUIRE_EQUAL(nb_values % 5, 0);
+    BOOST_REQUIRE_EQUAL(nb_values % range, 0);
     
     HMap map = utils::get_filled_hash_map<HMap>(nb_values);
-    HMap map2 = utils::get_filled_hash_map<HMap>(nb_values);
     
     auto it = map.begin();
-    // Use second map to check for key after delete as we may not copy the key with move-only types.
-    auto it2 = map2.begin();
     while(it != map.end()) {
         it = map.erase(it, std::next(it, range));
         nb_values -= range;
         
         BOOST_CHECK_EQUAL(map.size(), nb_values);
-        it2 = std::next(it2, range);
     }
     
     BOOST_CHECK(map.empty());

--- a/tests/ordered_set_tests.cpp
+++ b/tests/ordered_set_tests.cpp
@@ -99,6 +99,22 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_insert, HSet, test_types) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(test_compare) {
+    const tsl::ordered_set<std::string> map = {"D", "L", "A"};
+    
+    BOOST_ASSERT(map == (tsl::ordered_set<std::string>{"D", "L", "A"}));
+    BOOST_ASSERT(map != (tsl::ordered_set<std::string>{"L", "D", "A"}));
+    
+    
+    BOOST_ASSERT(map < (tsl::ordered_set<std::string>{"D", "L", "B"}));
+    BOOST_ASSERT(map <= (tsl::ordered_set<std::string>{"D", "L", "B"}));
+    BOOST_ASSERT(map <= (tsl::ordered_set<std::string>{"D", "L", "A"}));
+    
+    BOOST_ASSERT(map > (tsl::ordered_set<std::string>{"D", {"K", 2}, "A"}));
+    BOOST_ASSERT(map >= (tsl::ordered_set<std::string>{"D", {"K", 2}, "A"}));
+    BOOST_ASSERT(map >= (tsl::ordered_set<std::string>{"D", "L", "A"}));
+}
+
 
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -34,6 +34,14 @@
 #include <utility>
 
 
+template<typename T>
+class identity_hash {
+public:    
+    std::size_t operator()(const T& value) const {
+        return static_cast<std::size_t>(value);
+    }
+};
+
 template<unsigned int MOD>
 class mod_hash {
 public:   


### PR DESCRIPTION
Correct moved state, a moved `tsl::ordered_map` or `tsl::ordered_set` can now still be used after a move. Previously the map ended up in a invalid state after a move but the standard mandates that a moved object should be in a valid (but unspecified) state so that it can still be used after a move.

The following code will now work:
```c++
tsl::ordered_set<int> set = {0, 1, 2, 3, 4};
tsl::ordered_set<int> set2 = std::move(set);
    
set.erase(0);
set.find(0);
set.insert(0);
```