### PR TITLE
Add support for large maps/sets (more than 2^32 - 1 elements) through an extra class template parameter (#16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The values are stored contiguously in an underlying structure, no holes in-betwe
 
 To resolve collisions on hashes, the library uses robin hood probing with backward shift deletion.
 
-The library provides a behaviour similar to a `std::deque/std::vector` with unique values but with an average time complexity of O(1) for lookups and an amortised time complexity of O(1) for insertions. This comes at the price of a little higher memory footprint (8 bytes per bucket).
+The library provides a behaviour similar to a `std::deque/std::vector` with unique values but with an average time complexity of O(1) for lookups and an amortised time complexity of O(1) for insertions. This comes at the price of a little higher memory footprint (8 bytes per bucket by default).
 
 Two classes are provided: `tsl::ordered_map` and `tsl::ordered_set`.
 
@@ -38,7 +38,7 @@ for(auto it = map.begin(); it != map.end(); ++it) {
     it.value() = 2; // Ok
 }
 ```
-- The map can only hold up to 2<sup>32</sup> - 1 values, that is 4 294 967 295 values.
+- By default the map can only hold up to 2<sup>32</sup> - 1 values, that is 4 294 967 295 values. This can be raised through the `IndexType` class template parameter, check the [API](https://tessil.github.io/ordered-map/classtsl_1_1ordered__map.html#details) for details. 
 - No support for some bucket related methods (like bucket_size, bucket, ...).
 
 

--- a/tests/ordered_map_tests.cpp
+++ b/tests/ordered_map_tests.cpp
@@ -759,6 +759,27 @@ BOOST_AUTO_TEST_CASE(test_modify_value) {
     }
 }
 
+/**
+ * max_size
+ */
+BOOST_AUTO_TEST_CASE(test_max_size) {
+    tsl::ordered_map<int, int, std::hash<int>, std::equal_to<int>, 
+                     std::allocator<std::pair<int, int>>, std::vector<std::pair<int, int>>, std::uint16_t> map;
+    BOOST_CHECK(map.max_size() <= std::numeric_limits<std::uint16_t>::max());
+    BOOST_CHECK(map.max_size() > std::numeric_limits<std::uint8_t>::max());
+    
+    
+    tsl::ordered_map<int, int, std::hash<int>, std::equal_to<int>, 
+                     std::allocator<std::pair<int, int>>, std::vector<std::pair<int, int>>, std::uint32_t> map2;
+    BOOST_CHECK(map2.max_size() <= std::numeric_limits<std::uint32_t>::max());
+    BOOST_CHECK(map2.max_size() > std::numeric_limits<std::uint16_t>::max());
+    
+    
+    tsl::ordered_map<int, int, std::hash<int>, std::equal_to<int>, 
+                     std::allocator<std::pair<int, int>>, std::vector<std::pair<int, int>>, std::uint64_t> map3;
+    BOOST_CHECK(map3.max_size() <= std::numeric_limits<std::uint64_t>::max());
+    BOOST_CHECK(map3.max_size() > std::numeric_limits<std::uint32_t>::max());
+}
 
 /**
  * constructor

--- a/tests/ordered_map_tests.cpp
+++ b/tests/ordered_map_tests.cpp
@@ -763,6 +763,7 @@ BOOST_AUTO_TEST_CASE(test_modify_value) {
  * max_size
  */
 BOOST_AUTO_TEST_CASE(test_max_size) {
+    // TODO not compatible on systems with sizeof(std::size_t) < sizeof(std::uint32_t), will not build.
     tsl::ordered_map<int, int, std::hash<int>, std::equal_to<int>, 
                      std::allocator<std::pair<int, int>>, std::vector<std::pair<int, int>>, std::uint16_t> map;
     BOOST_CHECK(map.max_size() <= std::numeric_limits<std::uint16_t>::max());
@@ -775,10 +776,12 @@ BOOST_AUTO_TEST_CASE(test_max_size) {
     BOOST_CHECK(map2.max_size() > std::numeric_limits<std::uint16_t>::max());
     
     
+    using max_size_type = std::conditional<sizeof(std::size_t) == sizeof(std::uint64_t), std::uint64_t, std::uint32_t>::type;
+    using min_size_type = std::conditional<sizeof(std::size_t) == sizeof(std::uint64_t), std::uint32_t, std::uint16_t>::type;
     tsl::ordered_map<int, int, std::hash<int>, std::equal_to<int>, 
-                     std::allocator<std::pair<int, int>>, std::vector<std::pair<int, int>>, std::uint64_t> map3;
-    BOOST_CHECK(map3.max_size() <= std::numeric_limits<std::uint64_t>::max());
-    BOOST_CHECK(map3.max_size() > std::numeric_limits<std::uint32_t>::max());
+                     std::allocator<std::pair<int, int>>, std::vector<std::pair<int, int>>, max_size_type> map3;
+    BOOST_CHECK(map3.max_size() <= std::numeric_limits<max_size_type>::max());
+    BOOST_CHECK(map3.max_size() > std::numeric_limits<min_size_type>::max());
 }
 
 /**

--- a/tsl/ordered_hash.h
+++ b/tsl/ordered_hash.h
@@ -123,7 +123,8 @@ struct is_vector<T, typename std::enable_if<
 template<class IndexType>
 class bucket_entry {
     static_assert(std::is_unsigned<IndexType>::value, "IndexType must be an unsigned value.");
-    static_assert(sizeof(IndexType) <= sizeof(std::size_t), "sizeof(IndexType) must be <= than sizeof(std::size_t).");
+    static_assert(std::numeric_limits<IndexType>::max() <= std::numeric_limits<std::size_t>::max(), 
+                  "std::numeric_limits<IndexType>::max() must be <= std::numeric_limits<std::size_t>::max().");
     
 public:
     using index_type = IndexType;

--- a/tsl/ordered_hash.h
+++ b/tsl/ordered_hash.h
@@ -1191,7 +1191,7 @@ private:
         for(std::size_t ivalue = from_ivalue; ivalue < m_values.size(); ivalue++) {
             // All the values in m_values have been shifted by delta. Find the bucket corresponding 
             // to the value m_values[ivalue]
-            const index_type old_index(ivalue - delta);
+            const index_type old_index = static_cast<index_type>(ivalue - delta);
             
             std::size_t ibucket = bucket_for_hash(hash_key(KeySelect()(m_values[ivalue])));
             while(m_buckets[ibucket].index() != old_index) {

--- a/tsl/ordered_hash.h
+++ b/tsl/ordered_hash.h
@@ -122,13 +122,13 @@ struct is_vector<T, typename std::enable_if<
  */
 template<class IndexType, class TruncatedHashType>
 class bucket_entry {
+    static_assert(std::is_unsigned<IndexType>::value, "IndexType must be an unsigned value.");
+    static_assert(sizeof(IndexType) <= sizeof(std::size_t), "sizeof(IndexType) must be <= than sizeof(std::size_t).");
+    static_assert(std::is_unsigned<TruncatedHashType>::value, "TruncatedHashType must be an unsigned value.");
+    
 public:
     using index_type = IndexType;
     using truncated_hash_type = TruncatedHashType;
-    
-    static_assert(std::is_unsigned<index_type>::value, "IndexType must be an unsigned value.");
-    static_assert(sizeof(index_type) <= sizeof(std::size_t), "sizeof(IndexType) must be <= than sizeof(std::size_t).");
-    static_assert(std::is_unsigned<truncated_hash_type>::value, "TruncatedHashType must be an unsigned value.");
     
     bucket_entry() noexcept: m_index(EMPTY_MARKER_INDEX), m_hash(0) {
     }
@@ -178,7 +178,7 @@ public:
     }
     
     static std::size_t max_size() noexcept {
-        return static_cast<std::size_t>(std::numeric_limits<index_type>::max() - NB_RESERVED_INDEXES);
+        return static_cast<std::size_t>(std::numeric_limits<index_type>::max()) - NB_RESERVED_INDEXES;
     }
     
 private:

--- a/tsl/ordered_hash.h
+++ b/tsl/ordered_hash.h
@@ -127,6 +127,7 @@ public:
     using truncated_hash_type = TruncatedHashType;
     
     static_assert(std::is_unsigned<index_type>::value, "IndexType must be an unsigned value.");
+    static_assert(sizeof(index_type) <= sizeof(std::size_t), "sizeof(IndexType) must be <= than sizeof(std::size_t).");
     static_assert(std::is_unsigned<truncated_hash_type>::value, "TruncatedHashType must be an unsigned value.");
     
     bucket_entry() noexcept: m_index(EMPTY_MARKER_INDEX), m_hash(0) {
@@ -177,7 +178,7 @@ public:
     }
     
     static std::size_t max_size() noexcept {
-        return std::numeric_limits<index_type>::max() - NB_RESERVED_INDEXES;
+        return static_cast<std::size_t>(std::numeric_limits<index_type>::max() - NB_RESERVED_INDEXES);
     }
     
 private:

--- a/tsl/ordered_map.h
+++ b/tsl/ordered_map.h
@@ -26,6 +26,7 @@
 
 
 #include <cstddef>
+#include <cstdint>
 #include <deque>
 #include <functional>
 #include <initializer_list>
@@ -53,6 +54,10 @@ namespace tsl {
  * 
  * The behaviour of the hash map is undefinded if the destructor of Key or T throws an exception.
  * 
+ * By default the maximum size of a map is limited to 2^32 - 1 values, if needed this can be changed through
+ * the IndexType template parameter. Using an `uint64_t` will raise this limit to 2^64 - 1 values but each
+ * bucket will use 16 bytes instead of 8 bytes in addition to the space needed to store the values.
+ * 
  * Iterators invalidation:
  *  - clear, operator=, reserve, rehash: always invalidate the iterators (also invalidate end()).
  *  - insert, emplace, emplace_hint, operator[]: when a std::vector is used as ValueTypeContainer 
@@ -67,7 +72,8 @@ template<class Key,
          class Hash = std::hash<Key>,
          class KeyEqual = std::equal_to<Key>,
          class Allocator = std::allocator<std::pair<Key, T>>,
-         class ValueTypeContainer = std::deque<std::pair<Key, T>, Allocator>>
+         class ValueTypeContainer = std::deque<std::pair<Key, T>, Allocator>,
+         class IndexType = std::uint_least32_t>
 class ordered_map {
 private:
     template<typename U>
@@ -100,7 +106,7 @@ private:
     };
     
     using ht = detail_ordered_hash::ordered_hash<std::pair<Key, T>, KeySelect, ValueSelect,
-                                                 Hash, KeyEqual, Allocator, ValueTypeContainer>;
+                                                 Hash, KeyEqual, Allocator, ValueTypeContainer, IndexType>;
     
 public:
     using key_type = typename ht::key_type;

--- a/tsl/ordered_set.h
+++ b/tsl/ordered_set.h
@@ -26,6 +26,7 @@
 
 
 #include <cstddef>
+#include <cstdint>
 #include <deque>
 #include <functional>
 #include <initializer_list>
@@ -52,6 +53,10 @@ namespace tsl {
  * 
  * The behaviour of the hash set is undefinded if the destructor of Key throws an exception.
  * 
+ * By default the maximum size of a set is limited to 2^32 - 1 values, if needed this can be changed through
+ * the IndexType template parameter. Using an `uint64_t` will raise this limit to 2^64 - 1 values but each
+ * bucket will use 16 bytes instead of 8 bytes in addition to the space needed to store the values.
+ * 
  * Iterators invalidation:
  *  - clear, operator=, reserve, rehash: always invalidate the iterators (also invalidate end()).
  *  - insert, emplace, emplace_hint, operator[]: when a std::vector is used as ValueTypeContainer 
@@ -65,7 +70,8 @@ template<class Key,
          class Hash = std::hash<Key>,
          class KeyEqual = std::equal_to<Key>,
          class Allocator = std::allocator<Key>,
-         class ValueTypeContainer = std::deque<Key, Allocator>>
+         class ValueTypeContainer = std::deque<Key, Allocator>,
+         class IndexType = std::uint_least32_t>
 class ordered_set {
 private:
     template<typename U>
@@ -85,7 +91,7 @@ private:
     };
     
     using ht = detail_ordered_hash::ordered_hash<Key, KeySelect, void,
-                                                 Hash, KeyEqual, Allocator, ValueTypeContainer>;
+                                                 Hash, KeyEqual, Allocator, ValueTypeContainer, IndexType>;
             
 public:
     using key_type = typename ht::key_type;


### PR DESCRIPTION
Add support for large maps/sets (more than 2^32 - 1 elements) through the `IndexType` class template parameter. The parameter allows us to configure the index type that is used in `bucket_entry`. 

By default a `bucket_entry` has a 32 bits integer index to map an element with its position in `m_values` and a 32 bits hash. Each `bucket_entry` entry takes thus 8 bytes and the map can only contains 2^32 - 1 elements (-1 due to a reserved value). 

Setting the `IndexType` to a 64 bits integer allows the map to contain more elements but each `bucket_entry` will take 16 bytes.

```c++
tsl::ordered_map<int, int, std::hash<int>, std::equal_to<int>, 
                 std::allocator<std::pair<int, int>>, 
                 std::vector<std::pair<int, int>>, std::uint64_t> map;
```