### PR TITLE
Add support for efficient serialization

### DIFF
--- a/include/tsl/ordered_hash.h
+++ b/include/tsl/ordered_hash.h
@@ -109,13 +109,13 @@ template<typename T, typename U>
 static T numeric_cast(U value, const char* error_message = "numeric_cast() failed.") {
     T ret = static_cast<T>(value);
     if(static_cast<U>(ret) != value) {
-        throw std::runtime_error(error_message);
+        TSL_OH_THROW_OR_TERMINATE(std::runtime_error, error_message);
     }
     
     const bool is_same_signedness = (std::is_unsigned<T>::value && std::is_unsigned<U>::value) ||
                                     (std::is_signed<T>::value && std::is_signed<U>::value);
     if(!is_same_signedness && (ret < T{}) != (value < U{})) {
-        throw std::runtime_error(error_message);
+        TSL_OH_THROW_OR_TERMINATE(std::runtime_error, error_message);
     }
     
     return ret;
@@ -1486,7 +1486,8 @@ private:
         // For now we only have one version of the serialization protocol. 
         // If it doesn't match there is a problem with the file.
         if(version != SERIALIZATION_PROTOCOL_VERSION) {
-            throw std::runtime_error("Can't deserialize the ordered_map/set. The protocol version header is invalid.");
+            TSL_OH_THROW_OR_TERMINATE(std::runtime_error, "Can't deserialize the ordered_map/set. "
+                                                          "The protocol version header is invalid.");
         }
         
         const slz_size_type nb_elements = deserialize_value<slz_size_type>(deserializer);
@@ -1523,8 +1524,9 @@ private:
             }
             
             if(load_factor() > this->max_load_factor()) {
-                throw std::runtime_error("Invalid max_load_factor. Check that the serializer and deserializer supports "
-                                         "floats correctly as they can be converted implicitely to ints.");
+                TSL_OH_THROW_OR_TERMINATE(std::runtime_error, "Invalid max_load_factor. Check that the serializer "
+                                                              "and deserializer supports floats correctly as they "
+                                                              "can be converted implicitely to ints.");
             }
         }
     }

--- a/include/tsl/ordered_hash.h
+++ b/include/tsl/ordered_hash.h
@@ -105,6 +105,41 @@ struct is_vector<T, typename std::enable_if<
                     >::type>: std::true_type {
 };
 
+template<typename T, typename U>
+static T numeric_cast(U value, const char* error_message = "numeric_cast() failed.") {
+    T ret = static_cast<T>(value);
+    if(static_cast<U>(ret) != value) {
+        throw std::runtime_error(error_message);
+    }
+    
+    const bool is_same_signedness = (std::is_unsigned<T>::value && std::is_unsigned<U>::value) ||
+                                    (std::is_signed<T>::value && std::is_signed<U>::value);
+    if(!is_same_signedness && (ret < T{}) != (value < U{})) {
+        throw std::runtime_error(error_message);
+    }
+    
+    return ret;
+}
+
+
+/**
+ * Fixed size type used to represent size_type values on serialization. Need to be big enough
+ * to represent a std::size_t on 32 and 64 bits platforms, and must be the same size on both platforms.
+ */
+using slz_size_type = std::uint64_t;
+static_assert(std::numeric_limits<slz_size_type>::max() >= std::numeric_limits<std::size_t>::max(),
+              "slz_size_type must be >= std::size_t");
+
+template<class T, class Deserializer>
+static T deserialize_value(Deserializer& deserializer) {
+    // MSVC < 2017 is not conformant, circumvent the problem by removing the template keyword
+#if defined (_MSC_VER) && _MSC_VER < 1910
+    return deserializer.Deserializer::operator()<T>();
+#else
+    return deserializer.Deserializer::template operator()<T>();
+#endif
+}
+
 
 /**
  * Each bucket entry stores an index which is the index in m_values corresponding to the bucket's value 
@@ -165,6 +200,27 @@ public:
     
     void set_hash(std::size_t hash) noexcept {
         m_hash = truncate_hash(hash);
+    }
+    
+    template<class Serializer>
+    void serialize(Serializer& serializer) const {
+        const slz_size_type index = m_index;
+        serializer(index);
+        
+        const slz_size_type hash = m_hash;
+        serializer(hash);
+    }
+    
+    template<class Deserializer>
+    static bucket_entry deserialize(Deserializer& deserializer) {
+        const slz_size_type index = deserialize_value<slz_size_type>(deserializer);
+        const slz_size_type hash = deserialize_value<slz_size_type>(deserializer);
+        
+        bucket_entry bentry;
+        bentry.m_index = numeric_cast<index_type>(index, "Deserialized index is too big.");
+        bentry.m_hash = numeric_cast<truncated_hash_type>(hash, "Deserialized hash is too big.");
+        
+        return bentry;
     }
     
     
@@ -1013,6 +1069,16 @@ public:
         return 1;
     }
     
+    template<class Serializer>
+    void serialize(Serializer& serializer) const {
+        serialize_impl(serializer);
+    }
+    
+    template<class Deserializer>
+    void deserialize(Deserializer& deserializer, bool hash_compatible) {
+        deserialize_impl(deserializer, hash_compatible);
+    }
+    
     friend bool operator==(const ordered_hash& lhs, const ordered_hash& rhs) {
         return lhs.m_values == rhs.m_values;
     }
@@ -1388,6 +1454,81 @@ private:
         }
     }
     
+    template<class Serializer>
+    void serialize_impl(Serializer& serializer) const {
+        const slz_size_type version = SERIALIZATION_PROTOCOL_VERSION;
+        serializer(version);
+        
+        const slz_size_type nb_elements = m_values.size();
+        serializer(nb_elements);
+        
+        const slz_size_type bucket_count = m_buckets_data.size();
+        serializer(bucket_count);
+        
+        const float max_load_factor = m_max_load_factor;
+        serializer(max_load_factor);
+        
+        
+        for(const value_type& value: m_values) {
+            serializer(value);
+        }
+        
+        for(const bucket_entry& bucket: m_buckets_data) {
+            bucket.serialize(serializer);
+        }
+    }
+    
+    template<class Deserializer>
+    void deserialize_impl(Deserializer& deserializer, bool hash_compatible) {
+        tsl_oh_assert(m_buckets_data.empty()); // Current hash table must be empty
+        
+        const slz_size_type version = deserialize_value<slz_size_type>(deserializer);
+        // For now we only have one version of the serialization protocol. 
+        // If it doesn't match there is a problem with the file.
+        if(version != SERIALIZATION_PROTOCOL_VERSION) {
+            throw std::runtime_error("Can't deserialize the ordered_map/set. The protocol version header is invalid.");
+        }
+        
+        const slz_size_type nb_elements = deserialize_value<slz_size_type>(deserializer);
+        const slz_size_type bucket_count_ds = deserialize_value<slz_size_type>(deserializer);
+        const float max_load_factor = deserialize_value<float>(deserializer);
+        
+        
+        this->max_load_factor(max_load_factor);
+        
+        if(bucket_count_ds == 0) {
+            tsl_oh_assert(nb_elements == 0);
+            return;
+        }
+        
+        
+        if(!hash_compatible) {
+            reserve(numeric_cast<size_type>(nb_elements, "Deserialized nb_elements is too big."));
+            for(slz_size_type el = 0; el < nb_elements; el++) {
+                insert(deserialize_value<value_type>(deserializer));
+            }
+        }
+        else {
+            m_buckets_data.reserve(numeric_cast<size_type>(bucket_count_ds, "Deserialized bucket_count is too big."));
+            m_buckets = m_buckets_data.data(),
+            m_mask = m_buckets_data.capacity() - 1; 
+            
+            reserve_space_for_values(nb_elements);
+            for(slz_size_type el = 0; el < nb_elements; el++) {
+                m_values.push_back(deserialize_value<value_type>(deserializer));
+            }
+            
+            for(slz_size_type b = 0; b < bucket_count_ds; b++) {
+                m_buckets_data.push_back(bucket_entry::deserialize(deserializer));
+            }
+            
+            if(load_factor() > this->max_load_factor()) {
+                throw std::runtime_error("Invalid max_load_factor. Check that the serializer and deserializer supports "
+                                         "floats correctly as they can be converted implicitely to ints.");
+            }
+        }
+    }
+    
     static std::size_t round_up_to_power_of_two(std::size_t value) {
         if(is_power_of_two(value)) {
             return value;
@@ -1418,6 +1559,10 @@ private:
     static const size_type REHASH_ON_HIGH_NB_PROBES__NPROBES = 128;
     static constexpr float REHASH_ON_HIGH_NB_PROBES__MIN_LOAD_FACTOR = 0.15f;
     
+    /**
+     * Protocol version currenlty used for serialization.
+     */
+    static const slz_size_type SERIALIZATION_PROTOCOL_VERSION = 1;
     
     /**
      * Return an always valid pointer to an static empty bucket_entry with last_bucket() == true.

--- a/include/tsl/ordered_hash.h
+++ b/include/tsl/ordered_hash.h
@@ -1513,7 +1513,7 @@ private:
             m_buckets = m_buckets_data.data(),
             m_mask = m_buckets_data.capacity() - 1; 
             
-            reserve_space_for_values(nb_elements);
+            reserve_space_for_values(numeric_cast<size_type>(nb_elements, "Deserialized nb_elements is too big."));
             for(slz_size_type el = 0; el < nb_elements; el++) {
                 m_values.push_back(deserialize_value<value_type>(deserializer));
             }

--- a/include/tsl/ordered_map.h
+++ b/include/tsl/ordered_map.h
@@ -773,6 +773,45 @@ public:
         return m_ht.unordered_erase(key, precalculated_hash); 
     }
     
+    /**
+     * Serialize the map through the `serializer` parameter.
+     * 
+     * The `serializer` parameter must be a function object that supports the following call:
+     *  - `template<typename U> void operator()(const U& value);` where the types `std::uint64_t`, `float` and `std::pair<Key, T>` must be supported for U.
+     * 
+     * The implementation leaves binary compatibilty (endianness, IEEE 754 for floats, ...) of the types it serializes
+     * in the hands of the `Serializer` function object if compatibilty is required.
+     */
+    template<class Serializer>
+    void serialize(Serializer& serializer) const {
+        m_ht.serialize(serializer);
+    }
+
+    /**
+     * Deserialize a previouly serialized map through the `deserializer` parameter.
+     * 
+     * The `deserializer` parameter must be a function object that supports the following calls:
+     *  - `template<typename U> U operator()();` where the types `std::uint64_t`, `float` and `std::pair<Key, T>` must be supported for U.
+     * 
+     * If the deserialized hash map type is hash compatible with the serialized map, the deserialization process can be
+     * sped up by setting `hash_compatible` to true. To be hash compatible, the Hash, KeyEqual and GrowthPolicy must behave the 
+     * same way than the ones used on the serialized map. The `std::size_t` must also be of the same size as the one on the platform used
+     * to serialize the map. If these criteria are not met, the behaviour is undefined with `hash_compatible` sets to true.
+     * 
+     * The behaviour is undefined if the type `Key` and `T` of the `ordered_map` are not the same as the
+     * types used during serialization.
+     * 
+     * The implementation leaves binary compatibilty (endianness, IEEE 754 for floats, size of int, ...) of the types it 
+     * deserializes in the hands of the `Deserializer` function object if compatibilty is required.
+     */
+    template<class Deserializer>
+    static ordered_map deserialize(Deserializer& deserializer, bool hash_compatible = false) {
+        ordered_map map(0);
+        map.m_ht.deserialize(deserializer, hash_compatible);
+
+        return map;
+    }
+    
     
     
     friend bool operator==(const ordered_map& lhs, const ordered_map& rhs) { return lhs.m_ht == rhs.m_ht; }

--- a/include/tsl/ordered_map.h
+++ b/include/tsl/ordered_map.h
@@ -794,9 +794,10 @@ public:
      *  - `template<typename U> U operator()();` where the types `std::uint64_t`, `float` and `std::pair<Key, T>` must be supported for U.
      * 
      * If the deserialized hash map type is hash compatible with the serialized map, the deserialization process can be
-     * sped up by setting `hash_compatible` to true. To be hash compatible, the Hash, KeyEqual and GrowthPolicy must behave the 
-     * same way than the ones used on the serialized map. The `std::size_t` must also be of the same size as the one on the platform used
-     * to serialize the map. If these criteria are not met, the behaviour is undefined with `hash_compatible` sets to true.
+     * sped up by setting `hash_compatible` to true. To be hash compatible, the Hash and KeyEqual must behave the same way 
+     * than the ones used on the serialized map. The `std::size_t` must also be of the same size as the one on the platform used
+     * to serialize the map, the same apply for `IndexType`. If these criteria are not met, the behaviour is undefined with 
+     * `hash_compatible` sets to true.
      * 
      * The behaviour is undefined if the type `Key` and `T` of the `ordered_map` are not the same as the
      * types used during serialization.

--- a/include/tsl/ordered_set.h
+++ b/include/tsl/ordered_set.h
@@ -628,6 +628,45 @@ public:
         return m_ht.unordered_erase(key, precalculated_hash); 
     }
     
+    /**
+     * Serialize the set through the `serializer` parameter.
+     * 
+     * The `serializer` parameter must be a function object that supports the following call:
+     *  - `void operator()(const U& value);` where the types `std::uint64_t`, `float` and `Key` must be supported for U.
+     * 
+     * The implementation leaves binary compatibilty (endianness, IEEE 754 for floats, ...) of the types it serializes
+     * in the hands of the `Serializer` function object if compatibilty is required.
+     */
+    template<class Serializer>
+    void serialize(Serializer& serializer) const {
+        m_ht.serialize(serializer);
+    }
+
+    /**
+     * Deserialize a previouly serialized set through the `deserializer` parameter.
+     * 
+     * The `deserializer` parameter must be a function object that supports the following calls:
+     *  - `template<typename U> U operator()();` where the types `std::uint64_t`, `float` and `Key` must be supported for U.
+     * 
+     * If the deserialized hash set type is hash compatible with the serialized set, the deserialization process can be
+     * sped up by setting `hash_compatible` to true. To be hash compatible, the Hash, KeyEqual and GrowthPolicy must behave the 
+     * same way than the ones used on the serialized set. The `std::size_t` must also be of the same size as the one on the platform used
+     * to serialize the set. If these criteria are not met, the behaviour is undefined with `hash_compatible` sets to true.
+     * 
+     * The behaviour is undefined if the type `Key` of the `ordered_set` is not the same as the
+     * type used during serialization.
+     * 
+     * The implementation leaves binary compatibilty (endianness, IEEE 754 for floats, size of int, ...) of the types it 
+     * deserializes in the hands of the `Deserializer` function object if compatibilty is required.
+     */
+    template<class Deserializer>
+    static ordered_set deserialize(Deserializer& deserializer, bool hash_compatible = false) {
+        ordered_set set(0);
+        set.m_ht.deserialize(deserializer, hash_compatible);
+
+        return set;
+    }
+    
     
     
     friend bool operator==(const ordered_set& lhs, const ordered_set& rhs) { return lhs.m_ht == rhs.m_ht; }

--- a/include/tsl/ordered_set.h
+++ b/include/tsl/ordered_set.h
@@ -649,10 +649,11 @@ public:
      *  - `template<typename U> U operator()();` where the types `std::uint64_t`, `float` and `Key` must be supported for U.
      * 
      * If the deserialized hash set type is hash compatible with the serialized set, the deserialization process can be
-     * sped up by setting `hash_compatible` to true. To be hash compatible, the Hash, KeyEqual and GrowthPolicy must behave the 
-     * same way than the ones used on the serialized set. The `std::size_t` must also be of the same size as the one on the platform used
-     * to serialize the set. If these criteria are not met, the behaviour is undefined with `hash_compatible` sets to true.
-     * 
+     * sped up by setting `hash_compatible` to true. To be hash compatible, the Hash and KeyEqual must behave the same way 
+     * than the ones used on the serialized map. The `std::size_t` must also be of the same size as the one on the platform used
+     * to serialize the map, the same apply for `IndexType`. If these criteria are not met, the behaviour is undefined with 
+     * `hash_compatible` sets to true.
+     *
      * The behaviour is undefined if the type `Key` of the `ordered_set` is not the same as the
      * type used during serialization.
      * 

--- a/tests/ordered_set_tests.cpp
+++ b/tests/ordered_set_tests.cpp
@@ -127,5 +127,38 @@ BOOST_AUTO_TEST_CASE(test_insert_pointer) {
     BOOST_CHECK_EQUAL(set.size(), 1);
     BOOST_CHECK_EQUAL(**set.begin(), value);
 }
+    
+/**
+ * serialize and deserialize
+ */
+BOOST_AUTO_TEST_CASE(test_serialize_desearialize) {
+    // insert x values; delete some values; serialize set; deserialize in new set; check equal.
+    // for deserialization, test it with and without hash compatibility.
+    const std::size_t nb_values = 1000;
+    
+    
+    tsl::ordered_set<move_only_test> set;
+    for(std::size_t i = 0; i < nb_values + 40; i++) {
+        set.insert(utils::get_key<move_only_test>(i));
+    }
+    
+    for(std::size_t i = nb_values; i < nb_values + 40; i++) {
+        set.erase(utils::get_key<move_only_test>(i));
+    }
+    BOOST_CHECK_EQUAL(set.size(), nb_values);
+
+    
+    
+    serializer serial;
+    set.serialize(serial);
+
+    deserializer dserial(serial.str());
+    auto set_deserialized = decltype(set)::deserialize(dserial, true);
+    BOOST_CHECK(set == set_deserialized);
+
+    deserializer dserial2(serial.str());
+    set_deserialized = decltype(set)::deserialize(dserial2, false);
+    BOOST_CHECK(set_deserialized == set);
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -207,4 +207,107 @@ inline HMap utils::get_filled_hash_map(std::size_t nb_elements) {
     return map;
 }
 
+
+template<class T>
+struct is_pair: std::false_type {
+};
+
+template <class T1, class T2>
+struct is_pair<std::pair<T1, T2>>: std::true_type {
+};
+
+/**
+ * serializer helper to test serialize(...) and deserialize(...) functions
+ */
+class serializer {
+public:
+    serializer() {
+        m_ostream.exceptions(m_ostream.badbit | m_ostream.failbit);
+    }
+    
+    template<class T>
+    void operator()(const T& val) {
+        serialize_impl(val);
+    }
+    
+    std::string str() const {
+        return m_ostream.str();
+    }
+    
+private:
+    template<typename T, typename U>
+    void serialize_impl(const std::pair<T, U>& val) {
+        serialize_impl(val.first);
+        serialize_impl(val.second);
+    }
+    
+    void serialize_impl(const std::string& val) {
+        serialize_impl(boost::numeric_cast<std::uint64_t>(val.size()));
+        m_ostream.write(val.data(), val.size());
+    }
+
+    void serialize_impl(const move_only_test& val) {
+        serialize_impl(val.value());
+    }
+
+    template<class T, 
+             typename std::enable_if<std::is_arithmetic<T>::value>::type* = nullptr>
+    void serialize_impl(const T& val) {
+        m_ostream.write(reinterpret_cast<const char*>(&val), sizeof(val));
+    }
+    
+private:
+    std::stringstream m_ostream;
+};
+
+class deserializer {
+public:
+    explicit deserializer(const std::string& init_str = ""): m_istream(init_str) {
+        m_istream.exceptions(m_istream.badbit | m_istream.failbit | m_istream.eofbit);
+    }
+    
+    template<class T>
+    T operator()() {
+        return deserialize_impl<T>();
+    }
+
+private:
+    template<class T, 
+             typename std::enable_if<is_pair<T>::value>::type* = nullptr>
+    T deserialize_impl() {
+        auto first = deserialize_impl<typename T::first_type>();
+        return std::make_pair(std::move(first), deserialize_impl<typename T::second_type>());
+    }
+    
+    template<class T, 
+             typename std::enable_if<std::is_same<std::string, T>::value>::type* = nullptr>
+    T deserialize_impl() {
+        const std::size_t str_size = boost::numeric_cast<std::size_t>(deserialize_impl<std::uint64_t>());
+        
+        // TODO std::string::data() return a const pointer pre-C++17. Avoid the inefficient double allocation.
+        std::vector<char> chars(str_size);
+        m_istream.read(chars.data(), str_size);
+        
+        return std::string(chars.data(), chars.size());
+    }
+
+    template<class T, 
+             typename std::enable_if<std::is_same<move_only_test, T>::value>::type* = nullptr>
+    move_only_test deserialize_impl() {
+        return move_only_test(deserialize_impl<std::int64_t>());
+    }
+
+    template<class T, 
+             typename std::enable_if<std::is_arithmetic<T>::value>::type* = nullptr>
+    T deserialize_impl() {
+        T val;
+        m_istream.read(reinterpret_cast<char*>(&val), sizeof(val));
+
+        return val;
+    }
+    
+private:
+    std::stringstream m_istream;
+};
+
 #endif


### PR DESCRIPTION
This PR adds two new methods 
* `template<class Serializer> void serialize(Serializer& serializer) const;` 
* `template<class Deserializer> static ordered_map/set deserialize(Deserializer& deserializer, bool hash_compatible = false);` 

to `tsl::ordered_map/set`. 

They take advantage of the internals of the data structure to provide an efficient way to serialize/deserialize the structure when `hash_compatible = true`.

Fix feature request #24.