### PR TITLE
Added pop_front to all three headers.

### DIFF
--- a/include/tsl/ordered_hash.h
+++ b/include/tsl/ordered_hash.h
@@ -1026,6 +1026,10 @@ public:
         tsl_oh_assert(!empty());
         erase(std::prev(end()));
     }
+    void pop_front() {
+        tsl_oh_assert(!empty());
+        erase(begin());
+    }
     
     
     /**

--- a/include/tsl/ordered_hash.h
+++ b/include/tsl/ordered_hash.h
@@ -987,7 +987,14 @@ public:
     const values_container_type& values_container() const noexcept {
         return m_values;
     }
-    
+    values_container_type extract_values_container() {
+      values_container_type output{};
+      std::swap(output, m_values);
+      for (auto &bucket : m_buckets_data)
+        bucket.clear();
+      return output;
+    }
+
     template<class U = values_container_type, typename std::enable_if<is_vector<U>::value>::type* = nullptr>    
     const typename values_container_type::value_type* data() const noexcept {
         return m_values.data();

--- a/include/tsl/ordered_map.h
+++ b/include/tsl/ordered_map.h
@@ -725,6 +725,7 @@ public:
     
     
     void pop_back() { m_ht.pop_back(); }
+    void pop_front() { m_ht.pop_front(); }
     
     /**
      * Faster erase operation with an O(1) average complexity but it doesn't preserve the insertion order.

--- a/include/tsl/ordered_map.h
+++ b/include/tsl/ordered_map.h
@@ -670,6 +670,7 @@ public:
      * and are contiguous in the structure, no holes (size() == values_container().size()).
      */
     const values_container_type& values_container() const noexcept { return m_ht.values_container(); }
+    values_container_type extract_values_container() { return m_ht.extract_values_container(); }
 
     template<class U = values_container_type, typename std::enable_if<tsl::detail_ordered_hash::is_vector<U>::value>::type* = nullptr>    
     size_type capacity() const noexcept { return m_ht.capacity(); }

--- a/include/tsl/ordered_set.h
+++ b/include/tsl/ordered_set.h
@@ -541,6 +541,7 @@ public:
      * and are contiguous in the structure, no holes (size() == values_container().size()).
      */        
     const values_container_type& values_container() const noexcept { return m_ht.values_container(); }
+    values_container_type extract_values_container() { return m_ht.extract_values_container(); }
 
     template<class U = values_container_type, typename std::enable_if<tsl::detail_ordered_hash::is_vector<U>::value>::type* = nullptr>    
     size_type capacity() const noexcept { return m_ht.capacity(); }

--- a/include/tsl/ordered_set.h
+++ b/include/tsl/ordered_set.h
@@ -580,6 +580,7 @@ public:
     
     
     void pop_back() { m_ht.pop_back(); }
+    void pop_front() { m_ht.pop_front(); }
     
     /**
      * Faster erase operation with an O(1) average complexity but it doesn't preserve the insertion order.


### PR DESCRIPTION
Added pop_front to all three headers, as it is useful to remove the least recently added element.

The present implementation works with std::deque as well as std::vector, albeit inefficiently in the latter case.