### PR TITLE
add function to release values_container

### DIFF
--- a/include/tsl/ordered_hash.h
+++ b/include/tsl/ordered_hash.h
@@ -1004,6 +1004,16 @@ class ordered_hash : private Hash, private KeyEqual {
     return m_values;
   }
 
+  values_container_type release() {
+    values_container_type ret;
+    for (auto& bucket : m_buckets_data) {
+      bucket.clear();
+    }
+    m_grow_on_next_insert = false;
+    std::swap(ret, m_values);
+    return ret;
+  }
+
   template <class U = values_container_type,
             typename std::enable_if<is_vector<U>::value>::type* = nullptr>
   const typename values_container_type::value_type* data() const noexcept {

--- a/include/tsl/ordered_map.h
+++ b/include/tsl/ordered_map.h
@@ -769,6 +769,15 @@ class ordered_map {
     return m_ht.values_container();
   }
 
+  /**
+   * Release the container in which the values are stored.
+   *
+   * The map is empty after this operation.
+   */
+  values_container_type release() {
+    return m_ht.release();
+  }
+
   template <class U = values_container_type,
             typename std::enable_if<
                 tsl::detail_ordered_hash::is_vector<U>::value>::type* = nullptr>

--- a/include/tsl/ordered_set.h
+++ b/include/tsl/ordered_set.h
@@ -625,6 +625,15 @@ class ordered_set {
     return m_ht.values_container();
   }
 
+  /**
+   * Release the container in which the values are stored.
+   *
+   * The set is empty after this operation.
+   */
+  values_container_type release() {
+    return m_ht.release();
+  }
+
   template <class U = values_container_type,
             typename std::enable_if<
                 tsl::detail_ordered_hash::is_vector<U>::value>::type* = nullptr>

--- a/tests/ordered_map_tests.cpp
+++ b/tests/ordered_map_tests.cpp
@@ -1204,6 +1204,17 @@ BOOST_AUTO_TEST_CASE(test_equal_range) {
 }
 
 /**
+ * release
+ */
+BOOST_AUTO_TEST_CASE(test_release) {
+  auto vec = std::deque<std::pair<int, int>>{{1,1}, {2,2}, {3,3}};
+  auto map = tsl::ordered_map<int, int>{vec.begin(), vec.end()};
+
+  BOOST_CHECK(map.release() == vec);
+  BOOST_CHECK(map.empty());
+}
+
+/**
  * data()
  */
 BOOST_AUTO_TEST_CASE(test_data) {


### PR DESCRIPTION
What about adding a function to release the underlying values container?

The use case would be to have some code that requires the elements of a container to be unique in a construction phase while afterward a simple vector/dequeue would be fine.