### PR TITLE
Add an erase_if function

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,17 @@ for(auto it = map.begin(); it != map.end(); ++it) {
 - By default the map can only hold up to 2<sup>32</sup> - 1 values, that is 4 294 967 295 values. This can be raised through the `IndexType` class template parameter, check the [API](https://tessil.github.io/ordered-map/classtsl_1_1ordered__map.html#details) for details. 
 - No support for some bucket related methods (like `bucket_size`, `bucket`, ...).
 
-
 Thread-safety guarantee is the same as `std::unordered_map`  (i.e. possible to have multiple concurrent readers with no writer).
-
-Concerning the strong exception guarantee, it holds only if `ValueContainer::emplace_back` has the strong exception guarantee (which is true for `std::vector` and `std::deque` as long as the type `T` is not a move-only type with a move constructor that may throw an exception, see [details](http://en.cppreference.com/w/cpp/container/vector/emplace_back#Exceptions)).
 
 These differences also apply between `std::unordered_set` and `tsl::ordered_set`.
 
+### Exception Guarantees
+
+If not mentioned otherwise, functions have the strong exception guarantee, see [details](https://en.cppreference.com/w/cpp/language/exceptions). We below list cases in which this guarantee is not provided.
+
+The guarantee is only provided if `ValueContainer::emplace_back` has the strong exception guarantee (which is true for `std::vector` and `std::deque` as long as the type `T` is not a move-only type with a move constructor that may throw an exception, see [details](http://en.cppreference.com/w/cpp/container/vector/emplace_back#Exceptions)).
+
+The `tsl::ordered_map::erase_if` and `tsl::ordered_set::erase_if` functions only have the guarantee under the preconditions listed in their documentation.
 
 ### Installation
 

--- a/include/tsl/ordered_hash.h
+++ b/include/tsl/ordered_hash.h
@@ -1099,26 +1099,23 @@ class ordered_hash : private Hash, private KeyEqual {
   }
 
   /**
-   * Clear a bucket without touching the container holding the values.
-   */
-  void clear_bucket(typename buckets_container_type::iterator it) {
-    tsl_oh_assert(it != m_buckets_data.end());
-    it->clear();
-    backward_shift(std::size_t(std::distance(m_buckets_data.begin(), it)));
-  }
-
-  /**
    * Remove all entries for which the given predicate matches.
    */
   template <class Predicate>
   size_type erase_if(Predicate &pred) {
+    // Clear a bucket without touching the container holding the values.
+    auto clear_bucket = [this](typename buckets_container_type::iterator it) {
+        tsl_oh_assert(it != m_buckets_data.end());
+        it->clear();
+        backward_shift(std::size_t(std::distance(m_buckets_data.begin(), it)));
+    };
     using const_ref = typename values_container_type::const_reference;
-    auto last = m_values.end();
+    const auto last = m_values.end();
     auto first = m_values.begin();
     for (; first != last; ++first) {
       if (pred(static_cast<const_ref>(*first))) {
         clear_bucket(find_key(KeySelect()(*first), hash_key(KeySelect()(*first))));
-        for (auto it = first; ++it != last; ) {
+        for (auto it = std::next(first); it != last; ) {
           auto it_bucket = find_key(KeySelect()(*it), hash_key(KeySelect()(*it)));
           if (pred(static_cast<const_ref>(*it))) {
             clear_bucket(it_bucket);

--- a/include/tsl/ordered_hash.h
+++ b/include/tsl/ordered_hash.h
@@ -1102,26 +1102,28 @@ class ordered_hash : private Hash, private KeyEqual {
    * Remove all entries for which the given predicate matches.
    */
   template <class Predicate>
-  size_type erase_if(Predicate &pred) {
+  size_type erase_if(Predicate& pred) {
     // Clear a bucket without touching the container holding the values.
     auto clear_bucket = [this](typename buckets_container_type::iterator it) {
-        tsl_oh_assert(it != m_buckets_data.end());
-        it->clear();
-        backward_shift(std::size_t(std::distance(m_buckets_data.begin(), it)));
+      tsl_oh_assert(it != m_buckets_data.end());
+      it->clear();
+      backward_shift(std::size_t(std::distance(m_buckets_data.begin(), it)));
     };
     using const_ref = typename values_container_type::const_reference;
     const auto last = m_values.end();
     auto first = m_values.begin();
     for (; first != last; ++first) {
       if (pred(static_cast<const_ref>(*first))) {
-        clear_bucket(find_key(KeySelect()(*first), hash_key(KeySelect()(*first))));
-        for (auto it = std::next(first); it != last; ) {
-          auto it_bucket = find_key(KeySelect()(*it), hash_key(KeySelect()(*it)));
+        clear_bucket(
+            find_key(KeySelect()(*first), hash_key(KeySelect()(*first))));
+        for (auto it = std::next(first); it != last;) {
+          auto it_bucket =
+              find_key(KeySelect()(*it), hash_key(KeySelect()(*it)));
           if (pred(static_cast<const_ref>(*it))) {
             clear_bucket(it_bucket);
-          }
-          else {
-            it_bucket->set_index(static_cast<index_type>(std::distance(m_values.begin(), first)));
+          } else {
+            it_bucket->set_index(static_cast<index_type>(
+                std::distance(m_values.begin(), first)));
             *first++ = std::move(*it);
           }
         }

--- a/include/tsl/ordered_hash.h
+++ b/include/tsl/ordered_hash.h
@@ -1116,7 +1116,7 @@ class ordered_hash : private Hash, private KeyEqual {
       if (pred(static_cast<const_ref>(*first))) {
         clear_bucket(
             find_key(KeySelect()(*first), hash_key(KeySelect()(*first))));
-        for (auto it = std::next(first); it != last;) {
+        for (auto it = std::next(first); it != last; ++it) {
           auto it_bucket =
               find_key(KeySelect()(*it), hash_key(KeySelect()(*it)));
           if (pred(static_cast<const_ref>(*it))) {

--- a/include/tsl/ordered_hash.h
+++ b/include/tsl/ordered_hash.h
@@ -1103,6 +1103,9 @@ class ordered_hash : private Hash, private KeyEqual {
     auto last = m_values.end();
     auto first = std::find_if(m_values.begin(), last, pred);
     if (first != last) {
+        auto it_bucket = find_key(KeySelect()(*first), hash_key(KeySelect()(*first)));
+        tsl_oh_assert(it_bucket != m_buckets_data.end());
+        it_bucket->clear();
         for (auto it = first; ++it != last; ) {
             auto it_bucket = find_key(KeySelect()(*it), hash_key(KeySelect()(*it)));
             tsl_oh_assert(it_bucket != m_buckets_data.end());

--- a/include/tsl/ordered_hash.h
+++ b/include/tsl/ordered_hash.h
@@ -1103,36 +1103,43 @@ class ordered_hash : private Hash, private KeyEqual {
    */
   template <class Predicate>
   size_type erase_if(Predicate& pred) {
+    // Get the bucket associated with the given element.
+    auto get_bucket = [this](typename values_container_type::iterator it) {
+      return find_key(KeySelect()(*it), hash_key(KeySelect()(*it)));
+    };
     // Clear a bucket without touching the container holding the values.
     auto clear_bucket = [this](typename buckets_container_type::iterator it) {
       tsl_oh_assert(it != m_buckets_data.end());
       it->clear();
       backward_shift(std::size_t(std::distance(m_buckets_data.begin(), it)));
     };
-    using const_ref = typename values_container_type::const_reference;
+    // Ensure that only const references are passed to the predicate.
+    auto cpred = [&pred](typename values_container_type::const_reference x) {
+      return pred(x);
+    };
+
+    // Find first element that matches the predicate.
     const auto last = m_values.end();
-    auto first = m_values.begin();
-    for (; first != last; ++first) {
-      if (pred(static_cast<const_ref>(*first))) {
-        clear_bucket(
-            find_key(KeySelect()(*first), hash_key(KeySelect()(*first))));
-        for (auto it = std::next(first); it != last; ++it) {
-          auto it_bucket =
-              find_key(KeySelect()(*it), hash_key(KeySelect()(*it)));
-          if (pred(static_cast<const_ref>(*it))) {
-            clear_bucket(it_bucket);
-          } else {
-            it_bucket->set_index(static_cast<index_type>(
-                std::distance(m_values.begin(), first)));
-            *first++ = std::move(*it);
-          }
-        }
-        auto deleted = static_cast<size_type>(std::distance(first, last));
-        m_values.erase(first, last);
-        return deleted;
+    auto first = std::find_if(m_values.begin(), last, cpred);
+    if (first == last) {
+      return 0;
+    }
+    // Remove all elements that match the predicate.
+    clear_bucket(get_bucket(first));
+    for (auto it = std::next(first); it != last; ++it) {
+      auto it_bucket = get_bucket(it);
+      if (cpred(*it)) {
+        clear_bucket(it_bucket);
+      } else {
+        it_bucket->set_index(
+            static_cast<index_type>(std::distance(m_values.begin(), first)));
+        *first++ = std::move(*it);
       }
     }
-    return 0;
+    // Resize the vector and return the number of deleted elements.
+    auto deleted = static_cast<size_type>(std::distance(first, last));
+    m_values.erase(first, last);
+    return deleted;
   }
 
   template <class Serializer>

--- a/include/tsl/ordered_map.h
+++ b/include/tsl/ordered_map.h
@@ -399,6 +399,17 @@ class ordered_map {
     return m_ht.erase(key, precalculated_hash);
   }
 
+  /**
+   * @copydoc erase(iterator pos)
+   *
+   * Erases all elements that satisfy the predicate pred. The method is in
+   * O(n).
+   */
+  template <class Predicate>
+  friend size_type erase_if(ordered_map &map, Predicate pred) {
+    return map.m_ht.erase_if(pred);
+  }
+
   void swap(ordered_map& other) { other.m_ht.swap(m_ht); }
 
   /*

--- a/include/tsl/ordered_map.h
+++ b/include/tsl/ordered_map.h
@@ -403,7 +403,10 @@ class ordered_map {
    * @copydoc erase(iterator pos)
    *
    * Erases all elements that satisfy the predicate pred. The method is in
-   * O(n).
+   * O(n). Note that the function only has the strong exception guarantee if
+   * the Predicate, Hash, and Key predicates and moves of keys and values do
+   * not throw. If an exception is raised, the object is in an invalid state.
+   * It can still be cleared and destroyed without leaking memory.
    */
   template <class Predicate>
   friend size_type erase_if(ordered_map &map, Predicate pred) {

--- a/include/tsl/ordered_set.h
+++ b/include/tsl/ordered_set.h
@@ -324,6 +324,17 @@ class ordered_set {
     return m_ht.erase(key, precalculated_hash);
   }
 
+  /**
+   * @copydoc erase(iterator pos)
+   *
+   * Erases all elements that satisfy the predicate pred. The method is in
+   * O(n).
+   */
+  template <class Predicate>
+  friend size_type erase_if(ordered_set &set, Predicate pred) {
+    return set.m_ht.erase_if(pred);
+  }
+
   void swap(ordered_set& other) { other.m_ht.swap(m_ht); }
 
   /*

--- a/include/tsl/ordered_set.h
+++ b/include/tsl/ordered_set.h
@@ -328,7 +328,10 @@ class ordered_set {
    * @copydoc erase(iterator pos)
    *
    * Erases all elements that satisfy the predicate pred. The method is in
-   * O(n).
+   * O(n). Note that the function only has the strong exception guarantee if
+   * the Predicate, Hash, and Key predicates and moves of keys and values do
+   * not throw. If an exception is raised, the object is in an invalid state.
+   * It can still be cleared and destroyed without leaking memory.
    */
   template <class Predicate>
   friend size_type erase_if(ordered_set &set, Predicate pred) {

--- a/tests/ordered_map_tests.cpp
+++ b/tests/ordered_map_tests.cpp
@@ -692,16 +692,28 @@ BOOST_AUTO_TEST_CASE(test_range_erase_same_iterators) {
  * erase_if
  */
 BOOST_AUTO_TEST_CASE(test_erase_if) {
-  using value_type = tsl::ordered_map<int, int>::value_type;
-  tsl::ordered_map<int, int> map{{1, 1}, {2, 2}, {3, 2}, {4, 2}, {5, 3}};
-  auto num = erase_if(map, [](value_type &x) { return x.second == 2; });
+  using map_type = tsl::ordered_map<int, int>;
+  using value_type = map_type::value_type;
+  tsl::ordered_map<int, int> map{{0, 2}, {16, 2}, {24, 2}, {5, 5},
+                                 {6, 2}, {7, 7},  {8, 8},  {9, 9}};
 
-  BOOST_CHECK_EQUAL(num, 3);
-  BOOST_CHECK_EQUAL(map.size(), 2);
-  BOOST_CHECK_EQUAL(map.front().first, 1);
-  BOOST_CHECK_EQUAL(map.front().second, 1);
-  BOOST_CHECK_EQUAL(map.back().first, 5);
-  BOOST_CHECK_EQUAL(map.back().second, 3);
+  auto n = erase_if(map, [](value_type const &x) { return x.second == 2; });
+  BOOST_CHECK_EQUAL(n, 4);
+
+  n = erase_if(map, [](value_type const &x) { return x.second == 2; });
+  BOOST_CHECK_EQUAL(n, 0);
+
+  BOOST_CHECK_EQUAL(map.size(), 4);
+
+  BOOST_CHECK_EQUAL(map.at(5), 5);
+  BOOST_CHECK_EQUAL(map.at(7), 7);
+  BOOST_CHECK_EQUAL(map.at(8), 8);
+  BOOST_CHECK_EQUAL(map.at(9), 9);
+
+  BOOST_CHECK(map.find(0) == map.end());
+  BOOST_CHECK(map.find(6) == map.end());
+  BOOST_CHECK(map.find(16) == map.end());
+  BOOST_CHECK(map.find(24) == map.end());
 }
 
 /**

--- a/tests/ordered_map_tests.cpp
+++ b/tests/ordered_map_tests.cpp
@@ -689,6 +689,22 @@ BOOST_AUTO_TEST_CASE(test_range_erase_same_iterators) {
 }
 
 /**
+ * erase_if
+ */
+BOOST_AUTO_TEST_CASE(test_erase_if) {
+  using value_type = tsl::ordered_map<int, int>::value_type;
+  tsl::ordered_map<int, int> map{{1, 1}, {2, 2}, {3, 2}, {4, 2}, {5, 3}};
+  auto num = erase_if(map, [](value_type &x) { return x.second == 2; });
+
+  BOOST_CHECK_EQUAL(num, 3);
+  BOOST_CHECK_EQUAL(map.size(), 2);
+  BOOST_CHECK_EQUAL(map.front().first, 1);
+  BOOST_CHECK_EQUAL(map.front().second, 1);
+  BOOST_CHECK_EQUAL(map.back().first, 5);
+  BOOST_CHECK_EQUAL(map.back().second, 3);
+}
+
+/**
  * unordered_erase
  */
 BOOST_AUTO_TEST_CASE(test_unordered_erase) {

--- a/tests/ordered_map_tests.cpp
+++ b/tests/ordered_map_tests.cpp
@@ -697,10 +697,10 @@ BOOST_AUTO_TEST_CASE(test_erase_if) {
   tsl::ordered_map<int, int> map{{0, 2}, {16, 2}, {24, 2}, {5, 5},
                                  {6, 2}, {7, 7},  {8, 8},  {9, 9}};
 
-  auto n = erase_if(map, [](value_type const &x) { return x.second == 2; });
+  auto n = erase_if(map, [](const value_type& x) { return x.second == 2; });
   BOOST_CHECK_EQUAL(n, 4);
 
-  n = erase_if(map, [](value_type const &x) { return x.second == 2; });
+  n = erase_if(map, [](const value_type& x) { return x.second == 2; });
   BOOST_CHECK_EQUAL(n, 0);
 
   BOOST_CHECK_EQUAL(map.size(), 4);

--- a/tests/ordered_set_tests.cpp
+++ b/tests/ordered_set_tests.cpp
@@ -123,6 +123,16 @@ BOOST_AUTO_TEST_CASE(test_insert_pointer) {
   BOOST_CHECK_EQUAL(**set.begin(), value);
 }
 
+BOOST_AUTO_TEST_CASE(test_erase_if) {
+  tsl::ordered_set<int> set{1, 2, 3, 4, 5};
+  auto num = erase_if(set, [](int x) { return 2 <= x && x <= 4; });
+
+  BOOST_CHECK_EQUAL(num, 3);
+  BOOST_CHECK_EQUAL(set.size(), 2);
+  BOOST_CHECK_EQUAL(set.front(), 1);
+  BOOST_CHECK_EQUAL(set.back(), 5);
+}
+
 /**
  * serialize and deserialize
  */


### PR DESCRIPTION
This PR adds an `erase_if` function to the map that removes all elements that satisfy a predicate. The function preserves the insertion order shifting elements if necessary. It runs in `O(n)`. I think that with the current interface it is only possible to implement  something running in `O(n^2)`.

C++20 adds a free-standing `erase_if` function for maps. The function here is defined in a similar way.