### PR TITLE
Fix shift_indexes_in_buckets by going through the whole m_buckets_data instead of finding back the bucket through m_values

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The ordered-map library provides a hash map and a hash set which preserve the order of insertion in a way similar to Python's [OrderedDict](https://docs.python.org/3/library/collections.html#collections.OrderedDict). When iterating over the map, the values will be returned in the same order as they were inserted.
 
-The values are stored contiguously in an underlying structure, no holes in-between values even after an erase operation. By default a `std::deque` is used for this structure, but it's also possible to  use a `std::vector`. This structure is directly accessible through the `values_container()` method and if the structure is a `std::vector`, a `data()` method is also provided to easily interact with C APIs. This provides fast iteration but with the drawback of an O(n) erase operation. An O(1) `pop_back()` and an O(1) `unordered_erase()` functions are available.
+The values are stored contiguously in an underlying structure, no holes in-between values even after an erase operation. By default a `std::deque` is used for this structure, but it's also possible to  use a `std::vector`. This structure is directly accessible through the `values_container()` method and if the structure is a `std::vector`, a `data()` method is also provided to easily interact with C APIs. This provides fast iteration but with the drawback of an O(bucket_count) erase operation. An O(1) `pop_back()` and an O(1) `unordered_erase()` functions are available. **If ordered erase is often used, another data structure is recommended.**
 
 To resolve collisions on hashes, the library uses linear robin hood probing with backward shift deletion.
 
@@ -30,7 +30,7 @@ Two classes are provided: `tsl::ordered_map` and `tsl::ordered_set`.
 `tsl::ordered_map` tries to have an interface similar to `std::unordered_map`, but some differences exist.
 - The iterators are `RandomAccessIterator`.
 - Iterator invalidation behaves in a way closer to `std::vector` and `std::deque` (see [API](https://tessil.github.io/ordered-map/classtsl_1_1ordered__map.html#details) for details). If you use `std::vector` as `ValueTypeContainer`, you can use `reserve()` to preallocate some space and avoid the invalidation of the iterators on insert.
-- Slow `erase()` operation, it has a complexity of O(n). A faster O(1) version `unordered_erase()` exists, but it breaks the insertion order (see [API](https://tessil.github.io/ordered-map/classtsl_1_1ordered__map.html#a9f94a7889fa7fa92eea41ca63b3f98a4) for details). An O(1) `pop_back()` is also available.
+- Slow `erase()` operation, it has a complexity of O(bucket_count). A faster O(1) version `unordered_erase()` exists, but it breaks the insertion order (see [API](https://tessil.github.io/ordered-map/classtsl_1_1ordered__map.html#a9f94a7889fa7fa92eea41ca63b3f98a4) for details). An O(1) `pop_back()` is also available.
 - The equality operators `operator==` and `operator!=` are order dependent. Two `tsl::ordered_map` with the same values but inserted in a different order don't compare equal.
 - For iterators, `operator*()` and `operator->()` return a reference and a pointer to `const std::pair<Key, T>` instead of `std::pair<const Key, T>` making the value `T` not modifiable. To modify the value you have to call the `value()` method of the iterator to get a mutable reference. Example:
 ```c++

--- a/include/tsl/ordered_map.h
+++ b/include/tsl/ordered_map.h
@@ -338,8 +338,8 @@ class ordered_map {
    * When erasing an element, the insert order will be preserved and no holes
    * will be present in the container returned by 'values_container()'.
    *
-   * The method is in O(n), if the order is not important 'unordered_erase(...)'
-   * method is faster with an O(1) average complexity.
+   * The method is in O(bucket_count()), if the order is not important 
+   * 'unordered_erase(...)' method is faster with an O(1) average complexity.
    */
   iterator erase(iterator pos) { return m_ht.erase(pos); }
 
@@ -789,7 +789,7 @@ class ordered_map {
    * Insert the value before pos shifting all the elements on the right of pos
    * (including pos) one position to the right.
    *
-   * Amortized linear time-complexity in the distance between pos and end().
+   * O(bucket_count()) runtime complexity.
    */
   std::pair<iterator, bool> insert_at_position(const_iterator pos,
                                                const value_type& value) {

--- a/include/tsl/ordered_set.h
+++ b/include/tsl/ordered_set.h
@@ -263,8 +263,8 @@ class ordered_set {
    * When erasing an element, the insert order will be preserved and no holes
    * will be present in the container returned by 'values_container()'.
    *
-   * The method is in O(n), if the order is not important 'unordered_erase(...)'
-   * method is faster with an O(1) average complexity.
+   * The method is in O(bucket_count()), if the order is not important 
+   * 'unordered_erase(...)' method is faster with an O(1) average complexity.
    */
   iterator erase(iterator pos) { return m_ht.erase(pos); }
 
@@ -645,7 +645,7 @@ class ordered_set {
    * Insert the value before pos shifting all the elements on the right of pos
    * (including pos) one position to the right.
    *
-   * Amortized linear time-complexity in the distance between pos and end().
+   * O(bucket_count()) runtime complexity.
    */
   std::pair<iterator, bool> insert_at_position(const_iterator pos,
                                                const value_type& value) {

--- a/tests/ordered_map_tests.cpp
+++ b/tests/ordered_map_tests.cpp
@@ -425,6 +425,20 @@ BOOST_AUTO_TEST_CASE(test_insert_at_position) {
                                                          {"Key7", 7}}));
 }
 
+BOOST_AUTO_TEST_CASE(test_insert_at_position_high_collisions) {
+  tsl::ordered_map<int, int, identity_hash<int>> map(32);
+  BOOST_CHECK_EQUAL(map.bucket_count(), 32);
+  map.insert({{0, 0}, {32, -32}, {64, -64}, {96, -96}, {128, -128}});
+
+  auto it = map.insert_at_position(map.begin(), {160, -160});
+  BOOST_CHECK(*it.first == (std::pair<int, int>(160, -160)));
+  BOOST_CHECK(it.second);
+  BOOST_CHECK(utils::test_is_equal(
+      map,
+      tsl::ordered_map<int, int, identity_hash<int>>{
+          {160, -160}, {0, 0}, {32, -32}, {64, -64}, {96, -96}, {128, -128}}));
+}
+
 /**
  * try_emplace_at_position
  */

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -155,6 +155,50 @@ class utils {
 
   template <typename HMap>
   static HMap get_filled_hash_map(std::size_t nb_elements);
+
+  /**
+   * The ordered_map equality operator only compares the m_values structure as
+   * it is sufficient for ensuring equality. This method do a more extensive
+   * comparison to ensure that the internal state of the map is coherent.
+   */
+  template <typename HMap>
+  static bool test_is_equal(const HMap& lhs, const HMap& rhs) {
+    if (lhs != rhs) {
+      return false;
+    }
+
+    for (const auto& val_lhs : lhs) {
+      auto it_rhs = rhs.find(val_lhs.first);
+      if (it_rhs == rhs.end()) {
+        return false;
+      }
+
+      if (val_lhs.first != it_rhs->first) {
+        return false;
+      }
+
+      if (val_lhs.second != it_rhs->second) {
+        return false;
+      }
+    }
+
+    for (const auto& val_rhs : rhs) {
+      auto it_lhs = lhs.find(val_rhs.first);
+      if (it_lhs == lhs.end()) {
+        return false;
+      }
+
+      if (it_lhs->first != val_rhs.first) {
+        return false;
+      }
+
+      if (it_lhs->second != val_rhs.second) {
+        return false;
+      }
+    }
+
+    return true;
+  }
 };
 
 template <>


### PR DESCRIPTION
Fix shift_indexes_in_buckets by going through the whole m_buckets_data instead of finding back the bucket through m_values

shift_indexes_in_buckets was trying to find back a bucket through m_values but as it modifies the indexes during the iteration, there's a risk of having two buckets with the same index for which we can't reliably know which one still need a shift by delta.

Fix issue #38