### PR TITLE
ci: Workflow dependencies pinned using hash values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
     name: ${{matrix.config.name}}
     runs-on: ${{matrix.config.os}}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2 # v4.2.2
 
     # Windows
     - name: Install boost (Windows)


### PR DESCRIPTION
This modify follows the [scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)'s recommendations.